### PR TITLE
Update migration with version number for rails 5.1

### DIFF
--- a/lib/entity_storage.rb
+++ b/lib/entity_storage.rb
@@ -73,7 +73,7 @@ module EntityStorage
   end
 
   # This migration is required for EntityStorage to work correctly
-  class AddEntitiesTable < ActiveRecord::Migration
+  class AddEntitiesTable < ActiveRecord::Migration[4.2]
 		# up and down functions call broken code in Rail3 migrations gem, called it 'create'
 
     def self.create


### PR DESCRIPTION
Without this change will get the following error with rails 5.1.7 and the rails server will crash.

```
/home/app/vendor/bundle/ruby/2.4.0/gems/activerecord-5.1.7/lib/active_record/migration.rb:525:in `inherited': Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for: (StandardError)
class EntityStorage::AddEntitiesTable < ActiveRecord::Migration[4.2]
from /home/app/vendor/bundle/ruby/2.4.0/gems/entity_storage-2.1.6/lib/entity_storage.rb:76:in `<module:EntityStorage>'
from /home/app/vendor/bundle/ruby/2.4.0/gems/entity_storage-2.1.6/lib/entity_storage.rb:11:in `<top (required)>'
from /usr/local/rvm/rubies/ruby-2.4.6/lib/ruby/site_ruby/2.4.0/bundler/runtime.rb:81:in `require'
from /usr/local/rvm/rubies/ruby-2.4.6/lib/ruby/site_ruby/2.4.0/bundler/runtime.rb:81:in `block (2 levels) in require'
from /usr/local/rvm/rubies/ruby-2.4.6/lib/ruby/site_ruby/2.4.0/bundler/runtime.rb:76:in `each'
from /usr/local/rvm/rubies/ruby-2.4.6/lib/ruby/site_ruby/2.4.0/bundler/runtime.rb:76:in `block in require'
from /usr/local/rvm/rubies/ruby-2.4.6/lib/ruby/site_ruby/2.4.0/bundler/runtime.rb:65:in `each'
from /usr/local/rvm/rubies/ruby-2.4.6/lib/ruby/site_ruby/2.4.0/bundler/runtime.rb:65:in `require'
from /usr/local/rvm/rubies/ruby-2.4.6/lib/ruby/site_ruby/2.4.0/bundler.rb:114:in `require'
```